### PR TITLE
PwnDBG documentation support

### DIFF
--- a/autogdb/docs/pwndbg/ai/ai.md
+++ b/autogdb/docs/pwndbg/ai/ai.md
@@ -1,0 +1,34 @@
+
+
+
+
+# ai
+
+## Description
+
+
+Ask GPT-3 a question about the current debugging context.
+## Usage:
+
+
+```bash
+usage: ai [-h] [-M MODEL] [-t TEMPERATURE] [-m MAX_TOKENS] [-v] [-L] [-c COMMAND] [question ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`question`|The question to ask.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-M`|`--model`|`None`|The OpenAI model to use.|
+|`-t`|`--temperature`|`None`|The temperature to use.|
+|`-m`|`--max-tokens`|`None`|The maximum number of tokens to generate.|
+|`-v`|`--verbose`||Print the prompt and response. (default: %(default)s)|
+|`-L`|`--list-models`||List the available models. (default: %(default)s)|
+|`-c`|`--command`|`None`|Run a command in the GDB debugger and ask a question about the output.|

--- a/autogdb/docs/pwndbg/argv/argc.md
+++ b/autogdb/docs/pwndbg/argv/argc.md
@@ -1,0 +1,22 @@
+
+
+
+
+# argc
+
+## Description
+
+
+Prints out the number of arguments.
+## Usage:
+
+
+```bash
+usage: argc [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/argv/argv.md
+++ b/autogdb/docs/pwndbg/argv/argv.md
@@ -1,0 +1,28 @@
+
+
+
+
+# argv
+
+## Description
+
+
+Prints out the contents of argv.
+## Usage:
+
+
+```bash
+usage: argv [-h] [i]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`i`|Index of the argument to print out.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/argv/envp.md
+++ b/autogdb/docs/pwndbg/argv/envp.md
@@ -1,0 +1,28 @@
+
+
+
+
+# envp
+
+## Description
+
+
+Prints out the contents of the environment.
+## Usage:
+
+
+```bash
+usage: envp [-h] [name]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`name`|Name of the environment variable to see.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/aslr/aslr.md
+++ b/autogdb/docs/pwndbg/aslr/aslr.md
@@ -1,0 +1,32 @@
+
+
+
+
+# aslr
+
+## Description
+
+
+
+Check the current ASLR status, or turn it on/off.
+
+Does not take effect until the program is restarted.
+
+## Usage:
+
+
+```bash
+usage: aslr [-h] [{on,off}]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`state`|Turn ASLR on or off (takes effect when target is started)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/asm/asm.md
+++ b/autogdb/docs/pwndbg/asm/asm.md
@@ -1,0 +1,36 @@
+
+
+
+
+# asm
+
+## Description
+
+
+Assemble shellcode into bytes
+## Usage:
+
+
+```bash
+usage: asm [-h] [-f {hex,string}] [--arch {powerpc64,aarch64,powerpc,riscv32,riscv64,sparc64,mips64,msp430,alpha,amd64,sparc,thumb,cris,i386,ia64,m68k,mips,s390,none,avr,arm,vax}]
+           [-v AVOID] [-n] [-z] [-i INFILE]
+           [shellcode ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`shellcode`|Assembler code to assemble (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-f`|`--format`|`hex`|Output format (default: %(default)s)|
+||`--arch`|`i386`|Target architecture (default: %(default)s)|
+|`-v`|`--avoid`|`None`|Encode the shellcode to avoid the listed bytes (provided as hex)|
+|`-n`|`--newline`|`None`|Encode the shellcode to avoid newlines|
+|`-z`|`--zero`|`None`|Encode the shellcode to avoid NULL bytes|
+|`-i`|`--infile`|`None`|Specify input file|

--- a/autogdb/docs/pwndbg/attachp/attachp.md
+++ b/autogdb/docs/pwndbg/attachp/attachp.md
@@ -1,0 +1,46 @@
+
+
+
+
+# attachp
+
+## Description
+
+
+Attaches to a given pid, process name or device file.
+
+This command wraps the original GDB `attach` command to add the ability
+to debug a process with given name. In such case the process identifier is
+fetched via the `pidof <name>` command.
+
+Original GDB attach command help:
+    Attach to a process or file outside of GDB.
+    This command attaches to another target, of the same type as your last
+    "target" command ("info files" will show your target stack).
+    The command may take as argument a process id or a device file.
+    For a process id, you must have permission to send the process a signal,
+    and it must have the same effective uid as the debugger.
+    When using "attach" with a process id, the debugger finds the
+    program running in the process, looking first in the current working
+    directory, or (if not found there) using the source file search path
+    (see the "directory" command).  You can also use the "file" command
+    to specify the program, and to load its symbol table.
+## Usage:
+
+
+```bash
+usage: attachp [-h] [--no-truncate] target
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`target`|pid, process name or device file to attach to|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+||`--no-truncate`||dont truncate command args (default: %(default)s)|

--- a/autogdb/docs/pwndbg/auxv/auxv.md
+++ b/autogdb/docs/pwndbg/auxv/auxv.md
@@ -1,0 +1,22 @@
+
+
+
+
+# auxv
+
+## Description
+
+
+Print information from the Auxiliary ELF Vector.
+## Usage:
+
+
+```bash
+usage: auxv [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/branch/break_if_not_taken.md
+++ b/autogdb/docs/pwndbg/branch/break_if_not_taken.md
@@ -1,0 +1,28 @@
+
+
+
+
+# break-if-not-taken
+
+## Description
+
+
+Breaks on a branch if it is not taken.
+## Usage:
+
+
+```bash
+usage: break-if-not-taken [-h] branch
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`branch`|The branch instruction to break on.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/branch/break_if_taken.md
+++ b/autogdb/docs/pwndbg/branch/break_if_taken.md
@@ -1,0 +1,28 @@
+
+
+
+
+# break-if-taken
+
+## Description
+
+
+Breaks on a branch if it is taken.
+## Usage:
+
+
+```bash
+usage: break-if-taken [-h] branch
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`branch`|The branch instruction to break on.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/canary/canary.md
+++ b/autogdb/docs/pwndbg/canary/canary.md
@@ -1,0 +1,22 @@
+
+
+
+
+# canary
+
+## Description
+
+
+Print out the current stack canary.
+## Usage:
+
+
+```bash
+usage: canary [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/checksec/checksec.md
+++ b/autogdb/docs/pwndbg/checksec/checksec.md
@@ -1,0 +1,22 @@
+
+
+
+
+# checksec
+
+## Description
+
+
+Prints out the binary security settings using `checksec`.
+## Usage:
+
+
+```bash
+usage: checksec [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/comments/comm.md
+++ b/autogdb/docs/pwndbg/comments/comm.md
@@ -1,0 +1,29 @@
+
+
+
+
+# comm
+
+## Description
+
+
+Put comments in assembly code.
+## Usage:
+
+
+```bash
+usage: comm [-h] [--addr address] comment
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`comment`|The text you want to comment|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+||`--addr`|`None`|Address to write comments|

--- a/autogdb/docs/pwndbg/config/config.md
+++ b/autogdb/docs/pwndbg/config/config.md
@@ -1,0 +1,28 @@
+
+
+
+
+# config
+
+## Description
+
+
+Shows pwndbg-specific configuration.
+## Usage:
+
+
+```bash
+usage: config [-h] [filter_pattern]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`filter_pattern`|Filter to apply to config parameters names/descriptions|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/config/configfile.md
+++ b/autogdb/docs/pwndbg/config/configfile.md
@@ -1,0 +1,23 @@
+
+
+
+
+# configfile
+
+## Description
+
+
+Generates a configuration file for the current pwndbg options.
+## Usage:
+
+
+```bash
+usage: configfile [-h] [--show-all]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+||`--show-all`||Display all configuration options. (default: %(default)s)|

--- a/autogdb/docs/pwndbg/config/theme.md
+++ b/autogdb/docs/pwndbg/config/theme.md
@@ -1,0 +1,28 @@
+
+
+
+
+# theme
+
+## Description
+
+
+Shows pwndbg-specific theme configuration.
+## Usage:
+
+
+```bash
+usage: theme [-h] [filter_pattern]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`filter_pattern`|Filter to apply to theme parameters names/descriptions|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/config/themefile.md
+++ b/autogdb/docs/pwndbg/config/themefile.md
@@ -1,0 +1,23 @@
+
+
+
+
+# themefile
+
+## Description
+
+
+Generates a configuration file for the current pwndbg theme options.
+## Usage:
+
+
+```bash
+usage: themefile [-h] [--show-all]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+||`--show-all`||Force displaying of all theme options. (default: %(default)s)|

--- a/autogdb/docs/pwndbg/context/context.md
+++ b/autogdb/docs/pwndbg/context/context.md
@@ -1,0 +1,28 @@
+
+
+
+
+# context
+
+## Description
+
+
+Print out the current register, instruction, and stack context.
+## Usage:
+
+
+```bash
+usage: context [-h] [subcontext ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`subcontext`|Submenu to display: 'reg', 'disasm', 'code', 'stack', 'backtrace', 'ghidra', and/or 'args'|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/context/contextoutput.md
+++ b/autogdb/docs/pwndbg/context/contextoutput.md
@@ -1,0 +1,32 @@
+
+
+
+
+# contextoutput
+
+## Description
+
+
+Sets the output of a context section.
+## Usage:
+
+
+```bash
+usage: contextoutput [-h] section path clearing [banner] [width]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`section`|The section which is to be configured. ('regs', 'disasm', 'code', 'stack', 'backtrace', and/or 'args')|
+|`path`|The path to which the output is written|
+|`clearing`|Indicates weather to clear the output|
+|`banner`|Where a banner should be placed: both, top , bottom, none (default: %(default)s)|
+|`width`|Sets a fixed width (used for banner). Set to None for auto|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/context/contextunwatch.md
+++ b/autogdb/docs/pwndbg/context/contextunwatch.md
@@ -1,0 +1,28 @@
+
+
+
+
+# contextunwatch
+
+## Description
+
+
+Removes an expression previously added to be watched.
+## Usage:
+
+
+```bash
+usage: contextunwatch [-h] num
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`num`|The expression number to be removed from context|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/context/contextwatch.md
+++ b/autogdb/docs/pwndbg/context/contextwatch.md
@@ -1,0 +1,33 @@
+
+
+
+
+# contextwatch
+
+## Description
+
+
+
+Adds an expression to be shown on context.
+
+To remove an expression, see `cunwatch`.
+
+## Usage:
+
+
+```bash
+usage: contextwatch [-h] [{eval,execute}] expression
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`cmd`|Command to be used with the expression. - eval: the expression is parsed and evaluated as in the debugged language. - execute: the expression is executed as a GDB command. (default: %(default)s)|
+|`expression`|The expression to be evaluated and shown in context|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/context/regs.md
+++ b/autogdb/docs/pwndbg/context/regs.md
@@ -1,0 +1,28 @@
+
+
+
+
+# regs
+
+## Description
+
+
+Print out all registers and enhance the information.
+## Usage:
+
+
+```bash
+usage: regs [-h] [regs ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`regs`|Registers to be shown|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/cpsr/cpsr.md
+++ b/autogdb/docs/pwndbg/cpsr/cpsr.md
@@ -1,0 +1,22 @@
+
+
+
+
+# cpsr
+
+## Description
+
+
+Print out ARM CPSR or xPSR register.
+## Usage:
+
+
+```bash
+usage: cpsr [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/cyclic/cyclic_cmd.md
+++ b/autogdb/docs/pwndbg/cyclic/cyclic_cmd.md
@@ -1,0 +1,31 @@
+
+
+
+
+# cyclic
+
+## Description
+
+
+Cyclic pattern creator/finder.
+## Usage:
+
+
+```bash
+usage: cyclic [-h] [-a charset] [-n length] [-l lookup_value | count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`count`|Number of characters to print from the sequence (default: print the entire sequence) (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-a`|`--alphabet`|`abcdefghijklmnopqrstuvwxyz`|The alphabet to use in the cyclic pattern (default: %(default)s)|
+|`-n`|`--length`|`None`|Size of the unique subsequences (defaults to the pointer size for the current arch)|
+|`-o`|`--lookup`|`None`|Do a lookup instead of printing the sequence (accepts constant values as well as expressions)|

--- a/autogdb/docs/pwndbg/cymbol/cymbol.md
+++ b/autogdb/docs/pwndbg/cymbol/cymbol.md
@@ -1,0 +1,27 @@
+
+
+
+
+# cymbol
+
+## Description
+
+
+Add, show, load, edit, or delete custom structures in plain C.
+## Usage:
+
+
+```bash
+usage: cymbol [-h] [-a name] [-r name] [-e name] [-l name] [-s name]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-a`|`--add`|`None`|Add a new custom structure|
+|`-r`|`--remove`|`None`|Remove an existing custom structure|
+|`-e`|`--edit`|`None`|Edit an existing custom structure|
+|`-l`|`--load`|`None`|Load an existing custom structure|
+|`-s`|`--show`|`None`|Show the source code of an existing custom structure|

--- a/autogdb/docs/pwndbg/distance/distance.md
+++ b/autogdb/docs/pwndbg/distance/distance.md
@@ -1,0 +1,29 @@
+
+
+
+
+# distance
+
+## Description
+
+
+Print the distance between the two arguments, or print the offset to the address's page base.
+## Usage:
+
+
+```bash
+usage: distance [-h] a [b]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`a`|The first address.|
+|`b`|The second address.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/dt/dt.md
+++ b/autogdb/docs/pwndbg/dt/dt.md
@@ -1,0 +1,33 @@
+
+
+
+
+# dt
+
+## Description
+
+
+
+    Dump out information on a type (e.g. ucontext_t).
+
+    Optionally overlay that information at an address.
+    
+## Usage:
+
+
+```bash
+usage: dt [-h] typename [address]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`typename`|The name of the structure being dumped.|
+|`address`|The address of the structure.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/dumpargs/dumpargs.md
+++ b/autogdb/docs/pwndbg/dumpargs/dumpargs.md
@@ -1,0 +1,23 @@
+
+
+
+
+# dumpargs
+
+## Description
+
+
+Prints determined arguments for call instruction.
+## Usage:
+
+
+```bash
+usage: dumpargs [-h] [-f]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-f`|`--force`||Force displaying of all arguments. (default: %(default)s)|

--- a/autogdb/docs/pwndbg/elf/elfsections.md
+++ b/autogdb/docs/pwndbg/elf/elfsections.md
@@ -1,0 +1,22 @@
+
+
+
+
+# elfsections
+
+## Description
+
+
+Prints the section mappings contained in the ELF header.
+## Usage:
+
+
+```bash
+usage: elfsections [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/elf/gotplt.md
+++ b/autogdb/docs/pwndbg/elf/gotplt.md
@@ -1,0 +1,22 @@
+
+
+
+
+# gotplt
+
+## Description
+
+
+Prints any symbols found in the .got.plt section if it exists.
+## Usage:
+
+
+```bash
+usage: gotplt [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/elf/plt.md
+++ b/autogdb/docs/pwndbg/elf/plt.md
@@ -1,0 +1,22 @@
+
+
+
+
+# plt
+
+## Description
+
+
+Prints any symbols found in the .plt section if it exists.
+## Usage:
+
+
+```bash
+usage: plt [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/flags/setflag.md
+++ b/autogdb/docs/pwndbg/flags/setflag.md
@@ -1,0 +1,29 @@
+
+
+
+
+# setflag
+
+## Description
+
+
+Modify the flags register.
+## Usage:
+
+
+```bash
+usage: setflag [-h] flag value
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`flag`|Flag for which you want to change the value|
+|`value`|Value to which you want to set the flag - only valid options are 0 and 1|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/got/got.md
+++ b/autogdb/docs/pwndbg/got/got.md
@@ -1,0 +1,38 @@
+
+
+
+
+# got
+
+## Description
+
+
+Show the state of the Global Offset Table.
+
+Examples:
+    got
+    got puts
+    got -p libc
+    got -a
+
+## Usage:
+
+
+```bash
+usage: got [-h] [-p PATH_FILTER | -a] [-r] [symbol_filter]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`symbol_filter`|Filter results by symbol name. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-p`|`--path`|``|Filter results by library/objfile path. (default: %(default)s)|
+|`-a`|`--all`||Process all libs/obfjiles including the target executable. (default: %(default)s)|
+|`-r`|`--show-readonly`||Also display read-only entries (which are filtered out by default). (default: %(default)s)|

--- a/autogdb/docs/pwndbg/got_tracking/track_got.md
+++ b/autogdb/docs/pwndbg/got_tracking/track_got.md
@@ -1,0 +1,22 @@
+
+
+
+
+# track-got
+
+## Description
+
+
+Controls GOT tracking
+## Usage:
+
+
+```bash
+usage: track-got [-h] {enable,disable,info,query} ...
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/heap/arena.md
+++ b/autogdb/docs/pwndbg/heap/arena.md
@@ -1,0 +1,30 @@
+
+
+
+
+# arena
+
+## Description
+
+
+Print the contents of an arena.
+
+Default to the current thread's arena.
+## Usage:
+
+
+```bash
+usage: arena [-h] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the arena.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/heap/arenas.md
+++ b/autogdb/docs/pwndbg/heap/arenas.md
@@ -1,0 +1,22 @@
+
+
+
+
+# arenas
+
+## Description
+
+
+List this process's arenas.
+## Usage:
+
+
+```bash
+usage: arenas [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/heap/bins.md
+++ b/autogdb/docs/pwndbg/heap/bins.md
@@ -1,0 +1,31 @@
+
+
+
+
+# bins
+
+## Description
+
+
+Print the contents of all an arena's bins and a thread's tcache.
+
+Default to the current thread's arena and tcache.
+## Usage:
+
+
+```bash
+usage: bins [-h] [addr] [tcache_addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the arena.|
+|`tcache_addr`|Address of the tcache.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/heap/fastbins.md
+++ b/autogdb/docs/pwndbg/heap/fastbins.md
@@ -1,0 +1,31 @@
+
+
+
+
+# fastbins
+
+## Description
+
+
+Print the contents of an arena's fastbins.
+
+Default to the current thread's arena.
+## Usage:
+
+
+```bash
+usage: fastbins [-h] [-v] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the arena.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-v`|`--verbose`||Show all fastbins, including empty ones (default: %(default)s)|

--- a/autogdb/docs/pwndbg/heap/find_fake_fast.md
+++ b/autogdb/docs/pwndbg/heap/find_fake_fast.md
@@ -1,0 +1,31 @@
+
+
+
+
+# find_fake_fast
+
+## Description
+
+
+Find candidate fake fast or tcache chunks overlapping the specified address.
+## Usage:
+
+
+```bash
+usage: find_fake_fast [-h] [--align] [--glibc-fastbin-bug] target_address [max_candidate_size]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`target_address`|Address of the word-sized value to overlap.|
+|`max_candidate_size`|Maximum size of fake chunks to find.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-a`|`--align`||Whether the fake chunk must be aligned to MALLOC_ALIGNMENT. This is required for tcache chunks and for all chunks when Safe Linking is enabled (default: %(default)s)|
+|`-b`|`--glibc-fastbin-bug`||Does the GLIBC fastbin size field bug affect the candidate size field width? (default: %(default)s)|

--- a/autogdb/docs/pwndbg/heap/heap.md
+++ b/autogdb/docs/pwndbg/heap/heap.md
@@ -1,0 +1,32 @@
+
+
+
+
+# heap
+
+## Description
+
+
+Iteratively print chunks on a heap.
+
+Default to the current thread's active heap.
+## Usage:
+
+
+```bash
+usage: heap [-h] [-v] [-s] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the first chunk (malloc_chunk struct start, prev_size field).|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-v`|`--verbose`||Print all chunk fields, even unused ones. (default: %(default)s)|
+|`-s`|`--simple`||Simply print malloc_chunk struct's contents. (default: %(default)s)|

--- a/autogdb/docs/pwndbg/heap/heap_config.md
+++ b/autogdb/docs/pwndbg/heap/heap_config.md
@@ -1,0 +1,28 @@
+
+
+
+
+# heap_config
+
+## Description
+
+
+Shows heap related configuration.
+## Usage:
+
+
+```bash
+usage: heap_config [-h] [filter_pattern]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`filter_pattern`|Filter to apply to config parameters names/descriptions|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/heap/hi.md
+++ b/autogdb/docs/pwndbg/heap/hi.md
@@ -1,0 +1,31 @@
+
+
+
+
+# hi
+
+## Description
+
+
+Searches all heaps to find if an address belongs to a chunk. If yes, prints the chunk.
+## Usage:
+
+
+```bash
+usage: hi [-h] [-v] [-s] [-f] addr
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the interest.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-v`|`--verbose`||Print all chunk fields, even unused ones. (default: %(default)s)|
+|`-s`|`--simple`||Simply print malloc_chunk struct's contents. (default: %(default)s)|
+|`-f`|`--fake`||Allow fake chunks. If set, displays any memory as a heap chunk (even if its not a real chunk). (default: %(default)s)|

--- a/autogdb/docs/pwndbg/heap/largebins.md
+++ b/autogdb/docs/pwndbg/heap/largebins.md
@@ -1,0 +1,31 @@
+
+
+
+
+# largebins
+
+## Description
+
+
+Print the contents of an arena's largebins.
+
+Default to the current thread's arena.
+## Usage:
+
+
+```bash
+usage: largebins [-h] [-v] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the arena.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-v`|`--verbose`||Show all largebins, including empty ones (default: %(default)s)|

--- a/autogdb/docs/pwndbg/heap/malloc_chunk.md
+++ b/autogdb/docs/pwndbg/heap/malloc_chunk.md
@@ -1,0 +1,31 @@
+
+
+
+
+# malloc_chunk
+
+## Description
+
+
+Print a chunk.
+## Usage:
+
+
+```bash
+usage: malloc_chunk [-h] [-f] [-v] [-s] addr
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the chunk (malloc_chunk struct start, prev_size field).|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-f`|`--fake`||Is this a fake chunk? (default: %(default)s)|
+|`-v`|`--verbose`||Print all chunk fields, even unused ones. (default: %(default)s)|
+|`-s`|`--simple`||Simply print malloc_chunk struct's contents. (default: %(default)s)|

--- a/autogdb/docs/pwndbg/heap/mp.md
+++ b/autogdb/docs/pwndbg/heap/mp.md
@@ -1,0 +1,22 @@
+
+
+
+
+# mp
+
+## Description
+
+
+Print the mp_ struct's contents.
+## Usage:
+
+
+```bash
+usage: mp [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/heap/smallbins.md
+++ b/autogdb/docs/pwndbg/heap/smallbins.md
@@ -1,0 +1,31 @@
+
+
+
+
+# smallbins
+
+## Description
+
+
+Print the contents of an arena's smallbins.
+
+Default to the current thread's arena.
+## Usage:
+
+
+```bash
+usage: smallbins [-h] [-v] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the arena.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-v`|`--verbose`||Show all smallbins, including empty ones (default: %(default)s)|

--- a/autogdb/docs/pwndbg/heap/tcache.md
+++ b/autogdb/docs/pwndbg/heap/tcache.md
@@ -1,0 +1,30 @@
+
+
+
+
+# tcache
+
+## Description
+
+
+Print a thread's tcache contents.
+
+Default to the current thread's tcache.
+## Usage:
+
+
+```bash
+usage: tcache [-h] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the tcache.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/heap/tcachebins.md
+++ b/autogdb/docs/pwndbg/heap/tcachebins.md
@@ -1,0 +1,31 @@
+
+
+
+
+# tcachebins
+
+## Description
+
+
+Print the contents of a tcache.
+
+Default to the current thread's tcache.
+## Usage:
+
+
+```bash
+usage: tcachebins [-h] [-v] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|The address of the tcache bins.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-v`|`--verbose`||Show all tcachebins, including empty ones (default: %(default)s)|

--- a/autogdb/docs/pwndbg/heap/top_chunk.md
+++ b/autogdb/docs/pwndbg/heap/top_chunk.md
@@ -1,0 +1,30 @@
+
+
+
+
+# top_chunk
+
+## Description
+
+
+Print relevant information about an arena's top chunk.
+
+Default to current thread's arena.
+## Usage:
+
+
+```bash
+usage: top_chunk [-h] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the arena.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/heap/try_free.md
+++ b/autogdb/docs/pwndbg/heap/try_free.md
@@ -1,0 +1,28 @@
+
+
+
+
+# try_free
+
+## Description
+
+
+Check what would happen if free was called with given address.
+## Usage:
+
+
+```bash
+usage: try_free [-h] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address passed to free|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/heap/unsortedbin.md
+++ b/autogdb/docs/pwndbg/heap/unsortedbin.md
@@ -1,0 +1,31 @@
+
+
+
+
+# unsortedbin
+
+## Description
+
+
+Print the contents of an arena's unsortedbin.
+
+Default to the current thread's arena.
+## Usage:
+
+
+```bash
+usage: unsortedbin [-h] [-v] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the arena.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-v`|`--verbose`||Show the "all" bin even if it's empty (default: %(default)s)|

--- a/autogdb/docs/pwndbg/heap/vis_heap_chunks.md
+++ b/autogdb/docs/pwndbg/heap/vis_heap_chunks.md
@@ -1,0 +1,34 @@
+
+
+
+
+# vis_heap_chunks
+
+## Description
+
+
+Visualize chunks on a heap.
+
+Default to the current arena's active heap.
+## Usage:
+
+
+```bash
+usage: vis_heap_chunks [-h] [--beyond_top] [--no_truncate] [--all_chunks] [count] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`count`|Number of chunks to visualize. (default: %(default)s)|
+|`addr`|Address of the first chunk.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-b`|`--beyond_top`||Attempt to keep printing beyond the top chunk. (default: %(default)s)|
+|`-n`|`--no_truncate`||Display all the chunk contents (Ignore the `max-visualize-chunk-size` configuration). (default: %(default)s)|
+|`-a`|`--all_chunks`|| Display all chunks (Ignore the default-visualize-chunk-number configuration). (default: %(default)s)|

--- a/autogdb/docs/pwndbg/hexdump/hexdump.md
+++ b/autogdb/docs/pwndbg/hexdump/hexdump.md
@@ -1,0 +1,29 @@
+
+
+
+
+# hexdump
+
+## Description
+
+
+Hexdumps data at the specified address or module name.
+## Usage:
+
+
+```bash
+usage: hexdump [-h] [address] [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|Address or module name to dump (default: %(default)s)|
+|`count`|Number of bytes to dump (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/ida/down.md
+++ b/autogdb/docs/pwndbg/ida/down.md
@@ -1,0 +1,28 @@
+
+
+
+
+# down
+
+## Description
+
+
+Select and print stack frame called by this one.
+## Usage:
+
+
+```bash
+usage: down [-h] [n]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`n`|The number of stack frames to go down. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/ida/j.md
+++ b/autogdb/docs/pwndbg/ida/j.md
@@ -1,0 +1,22 @@
+
+
+
+
+# j
+
+## Description
+
+
+Synchronize IDA's cursor with GDB.
+## Usage:
+
+
+```bash
+usage: j [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/ida/save_ida.md
+++ b/autogdb/docs/pwndbg/ida/save_ida.md
@@ -1,0 +1,22 @@
+
+
+
+
+# save_ida
+
+## Description
+
+
+Save the ida database.
+## Usage:
+
+
+```bash
+usage: save_ida [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/ida/up.md
+++ b/autogdb/docs/pwndbg/ida/up.md
@@ -1,0 +1,28 @@
+
+
+
+
+# up
+
+## Description
+
+
+Select and print stack frame that called this one.
+## Usage:
+
+
+```bash
+usage: up [-h] [n]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`n`|The number of stack frames to go up. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/ignore/ignore.md
+++ b/autogdb/docs/pwndbg/ignore/ignore.md
@@ -1,0 +1,33 @@
+
+
+
+
+# ignore
+
+## Description
+
+
+Set ignore-count of breakpoint number N to COUNT.
+
+While the ignore count is positive, execution will not stop on the breakpoint.
+
+By default, if `N' is ommitted, the last breakpoint (i.e. greatest breakpoint number) will be used.
+## Usage:
+
+
+```bash
+usage: ignore [-h] [N] COUNT
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`bpnum`|The breakpoint number N.|
+|`count`|The number to set COUNT.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/index.md
+++ b/autogdb/docs/pwndbg/index.md
@@ -1,0 +1,193 @@
+# Supported Pwndbg Commands
+
+## Linux/libc/ELF
+
+-  [argc](argv/argc.md) Prints out the number of arguments.
+-  [argv](argv/argv.md) Prints out the contents of argv.
+-  [envp](argv/envp.md) Prints out the contents of the environment.
+-  [aslr](aslr/aslr.md) 
+-  [auxv](auxv/auxv.md) Print information from the Auxiliary ELF Vector.
+-  [elfsections](elf/elfsections.md) Prints the section mappings contained in the ELF header.
+-  [gotplt](elf/gotplt.md) Prints any symbols found in the .got.plt section if it exists.
+-  [plt](elf/plt.md) Prints any symbols found in the .plt section if it exists.
+-  [got](got/got.md) Show the state of the Global Offset Table.
+-  [track-got](got_tracking/track_got.md) Controls GOT tracking
+-  [linkmap](linkmap/linkmap.md) Show the state of the Link Map
+-  [errno](misc/errno_.md) Converts errno (or argument) to its string representation.
+-  [piebase](pie/piebase.md) Calculate VA of RVA from PIE base.
+-  [threads](tls/threads.md) List all threads belonging to the selected inferior.
+-  [tls](tls/tls.md) Print out base address of the current Thread Local Storage (TLS).
+
+## Misc
+
+-  [asm](asm/asm.md) Assemble shellcode into bytes
+-  [break-if-not-taken](branch/break_if_not_taken.md) Breaks on a branch if it is not taken.
+-  [break-if-taken](branch/break_if_taken.md) Breaks on a branch if it is taken.
+-  [checksec](checksec/checksec.md) Prints out the binary security settings using `checksec`.
+-  [comm](comments/comm.md) Put comments in assembly code.
+-  [cyclic](cyclic/cyclic_cmd.md) Cyclic pattern creator/finder.
+-  [cymbol](cymbol/cymbol.md) Add, show, load, edit, or delete custom structures in plain C.
+-  [dt](dt/dt.md) 
+-  [dumpargs](dumpargs/dumpargs.md) Prints determined arguments for call instruction.
+-  [down](ida/down.md) Select and print stack frame called by this one.
+-  [up](ida/up.md) Select and print stack frame that called this one.
+-  [ipi](ipython_interactive/ipi.md) Start an interactive IPython prompt.
+-  [stepuntilasm](next/stepuntilasm.md) Breaks on the next matching instruction.
+-  [patch](patch/patch.md) Patches given instruction with given code or bytes.
+-  [patch_list](patch/patch_list.md) List all patches.
+-  [patch_revert](patch/patch_revert.md) Revert patch at given address.
+-  [getfile](peda/getfile.md) Gets the current file.
+-  [plist](plist/plist.md) Dumps the elements of a linked list.
+-  [sigreturn](sigreturn/sigreturn.md) Display the SigreturnFrame at the specific address
+-  [spray](spray/spray.md) Spray memory with cyclic() generated values
+-  [tips](tips/tips.md) Shows tips.
+-  [valist](valist/valist.md) Dumps the arguments of a va_list.
+
+## Start
+
+-  [attachp](attachp/attachp.md) Attaches to a given pid, process name or device file.
+-  [entry](start/entry.md) 
+-  [sstart](start/sstart.md) Alias for 'tbreak __libc_start_main; run'.
+-  [start](start/start.md) 
+
+## Stack
+
+-  [canary](canary/canary.md) Print out the current stack canary.
+-  [retaddr](stack/retaddr.md) Print out the stack addresses that contain return addresses.
+-  [stack](telescope/stack.md) Dereferences on stack data with specified count and offset.
+-  [stackf](telescope/stackf.md) Dereferences on stack data, printing the entire stack frame with specified count and offset .
+
+## pwndbg
+
+-  [config](config/config.md) Shows pwndbg-specific configuration.
+-  [configfile](config/configfile.md) Generates a configuration file for the current pwndbg options.
+-  [theme](config/theme.md) Shows pwndbg-specific theme configuration.
+-  [themefile](config/themefile.md) Generates a configuration file for the current pwndbg theme options.
+-  [memoize](memoize/memoize.md) 
+-  [pwndbg](misc/pwndbg_.md) Prints out a list of all pwndbg commands.
+-  [reinit_pwndbg](reload/reinit_pwndbg.md) Makes pwndbg reinitialize all state.
+-  [reload](reload/reload.md) Reload pwndbg.
+-  [bugreport](version/bugreport.md) Generate a bug report.
+-  [version](version/version.md) Displays GDB, Python, and pwndbg versions.
+
+## Context
+
+-  [context](context/context.md) Print out the current register, instruction, and stack context.
+-  [contextoutput](context/contextoutput.md) Sets the output of a context section.
+-  [contextunwatch](context/contextunwatch.md) Removes an expression previously added to be watched.
+-  [contextwatch](context/contextwatch.md) 
+-  [regs](context/regs.md) Print out all registers and enhance the information.
+-  [xinfo](xinfo/xinfo.md) Shows offsets of the specified address from various useful locations.
+
+## Register
+
+-  [cpsr](cpsr/cpsr.md) Print out ARM CPSR or xPSR register.
+-  [setflag](flags/setflag.md) Modify the flags register.
+-  [fsbase](segments/fsbase.md) Prints out the FS base address. See also $fsbase.
+-  [gsbase](segments/gsbase.md) Prints out the GS base address. See also $gsbase.
+
+## Memory
+
+-  [distance](distance/distance.md) Print the distance between the two arguments, or print the offset to the address's page base.
+-  [hexdump](hexdump/hexdump.md) Hexdumps data at the specified address or module name.
+-  [leakfind](leakfind/leakfind.md) 
+-  [mmap](mmap/mmap.md) 
+-  [mprotect](mprotect/mprotect.md) 
+-  [p2p](p2p/p2p.md) Pointer to pointer chain search. Searches given mapping for all pointers that point to specified mapping.
+-  [telescope](p2p/ts.md) Recursively dereferences pointers starting at the specified address.
+-  [telescope](peda/xprint.md) Recursively dereferences pointers starting at the specified address.
+-  [probeleak](probeleak/probeleak.md) 
+-  [search](search/search.md) Search memory for byte sequences, strings, pointers, and integer values.
+-  [telescope](telescope/telescope.md) Recursively dereferences pointers starting at the specified address.
+-  [vmmap](vmmap/vmmap.md) Print virtual memory map pages.
+-  [vmmap_add](vmmap/vmmap_add.md) Add virtual memory map page.
+-  [vmmap_clear](vmmap/vmmap_clear.md) Clear the vmmap cache.
+-  [vmmap_load](vmmap/vmmap_load.md) Load virtual memory map pages from ELF file.
+-  [xinfo](xinfo/xinfo.md) Shows offsets of the specified address from various useful locations.
+-  [memfrob](xor/memfrob.md) Memfrobs a region of memory (xor with '*').
+-  [xor](xor/xor.md) XOR `count` bytes at `address` with the key `key`.
+
+## Heap
+
+-  [arena](heap/arena.md) Print the contents of an arena.
+-  [arenas](heap/arenas.md) List this process's arenas.
+-  [bins](heap/bins.md) Print the contents of all an arena's bins and a thread's tcache.
+-  [fastbins](heap/fastbins.md) Print the contents of an arena's fastbins.
+-  [find_fake_fast](heap/find_fake_fast.md) Find candidate fake fast or tcache chunks overlapping the specified address.
+-  [heap](heap/heap.md) Iteratively print chunks on a heap.
+-  [heap_config](heap/heap_config.md) Shows heap related configuration.
+-  [hi](heap/hi.md) Searches all heaps to find if an address belongs to a chunk. If yes, prints the chunk.
+-  [largebins](heap/largebins.md) Print the contents of an arena's largebins.
+-  [malloc_chunk](heap/malloc_chunk.md) Print a chunk.
+-  [mp](heap/mp.md) Print the mp_ struct's contents.
+-  [smallbins](heap/smallbins.md) Print the contents of an arena's smallbins.
+-  [tcache](heap/tcache.md) Print a thread's tcache contents.
+-  [tcachebins](heap/tcachebins.md) Print the contents of a tcache.
+-  [top_chunk](heap/top_chunk.md) Print relevant information about an arena's top chunk.
+-  [try_free](heap/try_free.md) Check what would happen if free was called with given address.
+-  [unsortedbin](heap/unsortedbin.md) Print the contents of an arena's unsortedbin.
+-  [vis_heap_chunks](heap/vis_heap_chunks.md) Visualize chunks on a heap.
+
+## Breakpoint
+
+-  [ignore](ignore/ignore.md) Set ignore-count of breakpoint number N to COUNT.
+-  [breakrva](pie/breakrva.md) Break at RVA from PIE base.
+
+## Kernel
+
+-  [kbase](kbase/kbase.md) Finds the kernel virtual base address.
+-  [kchecksec](kchecksec/kchecksec.md) Checks for kernel hardening configuration options.
+-  [kcmdline](kcmdline/kcmdline.md) Return the kernel commandline (/proc/cmdline).
+-  [kconfig](kconfig/kconfig.md) Outputs the kernel config (requires CONFIG_IKCONFIG).
+-  [kversion](kversion/kversion.md) Outputs the kernel version (/proc/version).
+-  [slab](slab/slab.md) Prints information about the slab allocator
+
+## Process
+
+-  [killthreads](killthreads/killthreads.md) Kill all or given threads.
+-  [pid](procinfo/pid.md) Gets the pid.
+-  [procinfo](procinfo/procinfo.md) Display information about the running process.
+
+## Disassemble
+
+-  [emulate](nearpc/emulate.md) Like nearpc, but will emulate instructions from the current $PC forward.
+-  [nearpc](nearpc/nearpc.md) Disassemble near a specified address.
+
+## Step/Next/Continue
+
+-  [nextcall](next/nextcall.md) Breaks at the next call instruction.
+-  [nextjmp](next/nextjmp.md) Breaks at the next jump instruction.
+-  [nextproginstr](next/nextproginstr.md) Breaks at the next instruction that belongs to the running program.
+-  [nextret](next/nextret.md) Breaks at next return-like instruction.
+-  [nextsyscall](next/nextsyscall.md) Breaks at the next syscall not taking branches.
+-  [stepover](next/stepover.md) Breaks on the instruction after this one.
+-  [stepret](next/stepret.md) Breaks at next return-like instruction by 'stepping' to it.
+-  [stepsyscall](next/stepsyscall.md) Breaks at the next syscall by taking branches.
+-  [xuntil](peda/xuntil.md) Continue execution until an address or function.
+
+## WinDbg
+
+-  [bc](windbg/bc.md) Clear the breakpoint with the specified index.
+-  [bd](windbg/bd.md) Disable the breakpoint with the specified index.
+-  [be](windbg/be.md) Enable the breakpoint with the specified index.
+-  [bl](windbg/bl.md) List breakpoints.
+-  [bp](windbg/bp.md) Set a breakpoint at the specified address.
+-  [da](windbg/da.md) Dump a string at the specified address.
+-  [db](windbg/db.md) Starting at the specified address, dump N bytes.
+-  [dc](windbg/dc.md) Starting at the specified address, hexdump.
+-  [dd](windbg/dd.md) Starting at the specified address, dump N dwords.
+-  [dds](windbg/dds.md) Dump pointers and symbols at the specified address.
+-  [dq](windbg/dq.md) Starting at the specified address, dump N qwords.
+-  [ds](windbg/ds.md) Dump a string at the specified address.
+-  [dw](windbg/dw.md) Starting at the specified address, dump N words.
+-  [eb](windbg/eb.md) Write hex bytes at the specified address.
+-  [ed](windbg/ed.md) Write hex dwords at the specified address.
+-  [eq](windbg/eq.md) Write hex qwords at the specified address.
+-  [ew](windbg/ew.md) Write hex words at the specified address.
+-  [ez](windbg/ez.md) Write a string at the specified address.
+-  [eza](windbg/eza.md) Write a string at the specified address.
+-  [go](windbg/go.md) Windbg compatibility alias for 'continue' command.
+-  [k](windbg/k.md) Print a backtrace (alias 'bt').
+-  [ln](windbg/ln.md) List the symbols nearest to the provided value.
+-  [pc](windbg/pc.md) Windbg compatibility alias for 'nextcall' command.
+-  [peb](windbg/peb.md) Not be windows.

--- a/autogdb/docs/pwndbg/ipython_interactive/ipi.md
+++ b/autogdb/docs/pwndbg/ipython_interactive/ipi.md
@@ -1,0 +1,22 @@
+
+
+
+
+# ipi
+
+## Description
+
+
+Start an interactive IPython prompt.
+## Usage:
+
+
+```bash
+usage: ipi [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/kbase/kbase.md
+++ b/autogdb/docs/pwndbg/kbase/kbase.md
@@ -1,0 +1,22 @@
+
+
+
+
+# kbase
+
+## Description
+
+
+Finds the kernel virtual base address.
+## Usage:
+
+
+```bash
+usage: kbase [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/kchecksec/kchecksec.md
+++ b/autogdb/docs/pwndbg/kchecksec/kchecksec.md
@@ -1,0 +1,22 @@
+
+
+
+
+# kchecksec
+
+## Description
+
+
+Checks for kernel hardening configuration options.
+## Usage:
+
+
+```bash
+usage: kchecksec [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/kcmdline/kcmdline.md
+++ b/autogdb/docs/pwndbg/kcmdline/kcmdline.md
@@ -1,0 +1,22 @@
+
+
+
+
+# kcmdline
+
+## Description
+
+
+Return the kernel commandline (/proc/cmdline).
+## Usage:
+
+
+```bash
+usage: kcmdline [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/kconfig/kconfig.md
+++ b/autogdb/docs/pwndbg/kconfig/kconfig.md
@@ -1,0 +1,28 @@
+
+
+
+
+# kconfig
+
+## Description
+
+
+Outputs the kernel config (requires CONFIG_IKCONFIG).
+## Usage:
+
+
+```bash
+usage: kconfig [-h] [config_name]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`config_name`|A config name to search for|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/killthreads/killthreads.md
+++ b/autogdb/docs/pwndbg/killthreads/killthreads.md
@@ -1,0 +1,35 @@
+
+
+
+
+# killthreads
+
+## Description
+
+
+Kill all or given threads.
+
+Switches to given threads and calls pthread_exit(0) on them.
+This is performed with scheduler-locking to prevent other threads from operating at the same time.
+
+Killing all other threads may be useful to use GDB checkpoints, e.g., to test given input & restart the execution to the point of interest (checkpoint).
+
+## Usage:
+
+
+```bash
+usage: killthreads [-h] [-a] [thread_ids ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`thread_ids`|Thread IDs to kill.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-a`|`--all`||Kill all threads except the current one. (default: %(default)s)|

--- a/autogdb/docs/pwndbg/kversion/kversion.md
+++ b/autogdb/docs/pwndbg/kversion/kversion.md
@@ -1,0 +1,22 @@
+
+
+
+
+# kversion
+
+## Description
+
+
+Outputs the kernel version (/proc/version).
+## Usage:
+
+
+```bash
+usage: kversion [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/leakfind/leakfind.md
+++ b/autogdb/docs/pwndbg/leakfind/leakfind.md
@@ -1,0 +1,38 @@
+
+
+
+
+# leakfind
+
+## Description
+
+
+
+Attempt to find a leak chain given a starting address.
+Scans memory near the given address, looks for pointers, and continues that process to attempt to find leaks.
+
+Example: leakfind $rsp --page_name=filename --max_offset=0x48 --max_depth=6. This would look for any chains of leaks that point to a section in filename which begin near $rsp, are never 0x48 bytes further from a known pointer, and are a maximum length of 6.
+
+## Usage:
+
+
+```bash
+usage: leakfind [-h] [-p [PAGE_NAME]] [-o [MAX_OFFSET]] [-d [MAX_DEPTH]] [-s [STEP]] [--negative_offset [NEGATIVE_OFFSET]] [address]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|Starting address to find a leak chain from (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-p`|`--page_name`|`None`|Substring required to be part of the name of any found pages|
+|`-o`|`--max_offset`|`72`|Max offset to add to addresses when looking for leak (default: %(default)s)|
+|`-d`|`--max_depth`|`4`|Maximum depth to follow pointers to (default: %(default)s)|
+|`-s`|`--step`|`1`|Step to add between pointers so they are considered. For example, if this is 4 it would only consider pointers at an offset divisible by 4 from the starting pointer (default: %(default)s)|
+||`--negative_offset`|`0`|Max negative offset to search before an address when looking for a leak (default: %(default)s)|

--- a/autogdb/docs/pwndbg/linkmap/linkmap.md
+++ b/autogdb/docs/pwndbg/linkmap/linkmap.md
@@ -1,0 +1,22 @@
+
+
+
+
+# linkmap
+
+## Description
+
+
+Show the state of the Link Map
+## Usage:
+
+
+```bash
+usage: linkmap [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/memoize/memoize.md
+++ b/autogdb/docs/pwndbg/memoize/memoize.md
@@ -1,0 +1,26 @@
+
+
+
+
+# memoize
+
+## Description
+
+
+
+Toggles memoization (caching).
+
+Useful for diagnosing caching-related bugs. Decreases performance.
+
+## Usage:
+
+
+```bash
+usage: memoize [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/misc/errno_.md
+++ b/autogdb/docs/pwndbg/misc/errno_.md
@@ -1,0 +1,28 @@
+
+
+
+
+# errno
+
+## Description
+
+
+Converts errno (or argument) to its string representation.
+## Usage:
+
+
+```bash
+usage: errno [-h] [err]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`err`|Errno; if not passed, it is retrieved from __errno_location|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/misc/pwndbg_.md
+++ b/autogdb/docs/pwndbg/misc/pwndbg_.md
@@ -1,0 +1,32 @@
+
+
+
+
+# pwndbg
+
+## Description
+
+
+Prints out a list of all pwndbg commands.
+## Usage:
+
+
+```bash
+usage: pwndbg [-h] [--shell | --all] [-c CATEGORY_ | --list-categories] [filter_pattern]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`filter_pattern`|Filter to apply to commands names/docs|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+||`--shell`||Only display shell commands (default: %(default)s)|
+||`--all`||Only display shell commands (default: %(default)s)|
+|`-c`|`--category`|`None`|Filter commands by category|
+||`--list-categories`||List command categories (default: %(default)s)|

--- a/autogdb/docs/pwndbg/mmap/mmap.md
+++ b/autogdb/docs/pwndbg/mmap/mmap.md
@@ -1,0 +1,62 @@
+
+
+
+
+# mmap
+
+## Description
+
+
+
+Calls the mmap syscall and prints its resulting address.
+
+Note that the mmap syscall may fail for various reasons
+(see `man mmap`) and, in case of failure, its return value
+will not be a valid pointer.
+
+PROT values: NONE (0), READ (1), WRITE (2), EXEC (4)
+MAP values: SHARED (1), PRIVATE (2), SHARED_VALIDATE (3), FIXED (0x10),
+            ANONYMOUS (0x20)
+
+Flags and protection values can be either a string containing the names of the
+flags or permissions or a single number corresponding to the bitwise OR of the
+protection and flag numbers.
+
+Examples:
+    mmap 0x0 4096 PROT_READ|PROT_WRITE|PROT_EXEC MAP_PRIVATE|MAP_ANONYMOUS -1 0
+     - Maps a new private+anonymous page with RWX permissions at a location
+       decided by the kernel.
+
+    mmap 0x0 4096 PROT_READ MAP_PRIVATE 10 0
+     - Maps 4096 bytes of the file pointed to by file descriptor number 10 with
+       read permission at a location decided by the kernel.
+
+    mmap 0xdeadbeef 0x1000
+     - Maps a new private+anonymous page with RWX permissions at a page boundary
+       near 0xdeadbeef.
+
+## Usage:
+
+
+```bash
+usage: mmap [-h] [--quiet] [--force] addr length [prot] [flags] [fd] [offset]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address hint to be given to mmap.|
+|`length`|Length of the mapping, in bytes. Needs to be greater than zero.|
+|`prot`|Prot enum or int as in mmap(2). Eg. "PROT_READ\|PROT_EXEC" or 7 (for RWX). (default: %(default)s)|
+|`flags`|Flags enum or int as in mmap(2). Eg. "MAP_PRIVATE\|MAP_ANONYMOUS" or 0x22. (default: %(default)s)|
+|`fd`|File descriptor of the file to be mapped, or -1 if using MAP_ANONYMOUS. (default: %(default)s)|
+|`offset`|Offset from the start of the file, in bytes, if using file based mapping. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-q`|`--quiet`||Disable address validity warnings and hints (default: %(default)s)|
+|`-f`|`--force`||Force potentially unsafe actions to happen (default: %(default)s)|

--- a/autogdb/docs/pwndbg/mprotect/mprotect.md
+++ b/autogdb/docs/pwndbg/mprotect/mprotect.md
@@ -1,0 +1,40 @@
+
+
+
+
+# mprotect
+
+## Description
+
+
+
+Calls the mprotect syscall and prints its result value.
+
+Note that the mprotect syscall may fail for various reasons
+(see `man mprotect`) and a non-zero error return value
+can be decoded with the `errno <value>` command.
+
+Examples:
+    mprotect $rsp 4096 PROT_READ|PROT_WRITE|PROT_EXEC
+    mprotect some_symbol 0x1000 PROT_NONE
+
+## Usage:
+
+
+```bash
+usage: mprotect [-h] addr length prot
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Page-aligned address to all mprotect on.|
+|`length`|Count of bytes to call mprotect on. Needs to be multiple of page size.|
+|`prot`|Prot string as in mprotect(2). Eg. "PROT_READ\|PROT_EXEC"|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/nearpc/emulate.md
+++ b/autogdb/docs/pwndbg/nearpc/emulate.md
@@ -1,0 +1,29 @@
+
+
+
+
+# emulate
+
+## Description
+
+
+Like nearpc, but will emulate instructions from the current $PC forward.
+## Usage:
+
+
+```bash
+usage: emulate [-h] [pc] [lines]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`pc`|Address to emulate near.|
+|`lines`|Number of lines to show on either side of the address.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/nearpc/nearpc.md
+++ b/autogdb/docs/pwndbg/nearpc/nearpc.md
@@ -1,0 +1,30 @@
+
+
+
+
+# nearpc
+
+## Description
+
+
+Disassemble near a specified address.
+## Usage:
+
+
+```bash
+usage: nearpc [-h] [-e] [pc] [lines]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`pc`|Address to disassemble near.|
+|`lines`|Number of lines to show on either side of the address.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-e`|`--emulate`||Whether to emulate instructions to find the next ones or just linearly disassemble. (default: %(default)s)|

--- a/autogdb/docs/pwndbg/next/nextcall.md
+++ b/autogdb/docs/pwndbg/next/nextcall.md
@@ -1,0 +1,28 @@
+
+
+
+
+# nextcall
+
+## Description
+
+
+Breaks at the next call instruction.
+## Usage:
+
+
+```bash
+usage: nextcall [-h] [symbol_regex]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`symbol_regex`|A regex matching the name of next symbol to be broken on before calling.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/next/nextjmp.md
+++ b/autogdb/docs/pwndbg/next/nextjmp.md
@@ -1,0 +1,22 @@
+
+
+
+
+# nextjmp
+
+## Description
+
+
+Breaks at the next jump instruction.
+## Usage:
+
+
+```bash
+usage: nextjmp [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/next/nextproginstr.md
+++ b/autogdb/docs/pwndbg/next/nextproginstr.md
@@ -1,0 +1,22 @@
+
+
+
+
+# nextproginstr
+
+## Description
+
+
+Breaks at the next instruction that belongs to the running program.
+## Usage:
+
+
+```bash
+usage: nextproginstr [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/next/nextret.md
+++ b/autogdb/docs/pwndbg/next/nextret.md
@@ -1,0 +1,22 @@
+
+
+
+
+# nextret
+
+## Description
+
+
+Breaks at next return-like instruction.
+## Usage:
+
+
+```bash
+usage: nextret [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/next/nextsyscall.md
+++ b/autogdb/docs/pwndbg/next/nextsyscall.md
@@ -1,0 +1,22 @@
+
+
+
+
+# nextsyscall
+
+## Description
+
+
+Breaks at the next syscall not taking branches.
+## Usage:
+
+
+```bash
+usage: nextsyscall [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/next/stepover.md
+++ b/autogdb/docs/pwndbg/next/stepover.md
@@ -1,0 +1,28 @@
+
+
+
+
+# stepover
+
+## Description
+
+
+Breaks on the instruction after this one.
+## Usage:
+
+
+```bash
+usage: stepover [-h] [addr]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|The address to break after.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/next/stepret.md
+++ b/autogdb/docs/pwndbg/next/stepret.md
@@ -1,0 +1,22 @@
+
+
+
+
+# stepret
+
+## Description
+
+
+Breaks at next return-like instruction by 'stepping' to it.
+## Usage:
+
+
+```bash
+usage: stepret [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/next/stepsyscall.md
+++ b/autogdb/docs/pwndbg/next/stepsyscall.md
@@ -1,0 +1,22 @@
+
+
+
+
+# stepsyscall
+
+## Description
+
+
+Breaks at the next syscall by taking branches.
+## Usage:
+
+
+```bash
+usage: stepsyscall [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/next/stepuntilasm.md
+++ b/autogdb/docs/pwndbg/next/stepuntilasm.md
@@ -1,0 +1,29 @@
+
+
+
+
+# stepuntilasm
+
+## Description
+
+
+Breaks on the next matching instruction.
+## Usage:
+
+
+```bash
+usage: stepuntilasm [-h] mnemonic [op_str ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`mnemonic`|The mnemonic of the instruction|
+|`op_str`|The operands of the instruction|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/p2p/p2p.md
+++ b/autogdb/docs/pwndbg/p2p/p2p.md
@@ -1,0 +1,30 @@
+
+
+
+
+# p2p
+
+## Description
+
+
+Pointer to pointer chain search. Searches given mapping for all pointers that point to specified mapping.
+
+Any chain length greater than 0 is valid. If only one mapping is given it just looks for any pointers in that mapping.
+## Usage:
+
+
+```bash
+usage: p2p [-h] mapping_names [mapping_names ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`mapping_names`|Mapping name |
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/p2p/ts.md
+++ b/autogdb/docs/pwndbg/p2p/ts.md
@@ -1,0 +1,32 @@
+
+
+
+
+# telescope
+
+## Description
+
+
+Recursively dereferences pointers starting at the specified address.
+## Usage:
+
+
+```bash
+usage: telescope [-h] [-r] [-f] [-i] [address] [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to telescope at. (default: %(default)s)|
+|`count`|The number of lines to show. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-r`|`--reverse`||Show <count> previous addresses instead of next ones (default: %(default)s)|
+|`-f`|`--frame`||Show the stack frame, from rsp to rbp (default: %(default)s)|
+|`-i`|`--inverse`||Show the stack reverse growth (default: %(default)s)|

--- a/autogdb/docs/pwndbg/patch/patch.md
+++ b/autogdb/docs/pwndbg/patch/patch.md
@@ -1,0 +1,30 @@
+
+
+
+
+# patch
+
+## Description
+
+
+Patches given instruction with given code or bytes.
+## Usage:
+
+
+```bash
+usage: patch [-h] [-q] address ins
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to patch|
+|`ins`|instruction[s]|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-q`|`--quiet`||don't print anything (default: %(default)s)|

--- a/autogdb/docs/pwndbg/patch/patch_list.md
+++ b/autogdb/docs/pwndbg/patch/patch_list.md
@@ -1,0 +1,22 @@
+
+
+
+
+# patch_list
+
+## Description
+
+
+List all patches.
+## Usage:
+
+
+```bash
+usage: patch_list [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/patch/patch_revert.md
+++ b/autogdb/docs/pwndbg/patch/patch_revert.md
@@ -1,0 +1,28 @@
+
+
+
+
+# patch_revert
+
+## Description
+
+
+Revert patch at given address.
+## Usage:
+
+
+```bash
+usage: patch_revert [-h] address
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|Address to revert patch on|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/peda/getfile.md
+++ b/autogdb/docs/pwndbg/peda/getfile.md
@@ -1,0 +1,22 @@
+
+
+
+
+# getfile
+
+## Description
+
+
+Gets the current file.
+## Usage:
+
+
+```bash
+usage: getfile [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/peda/xinfo.md
+++ b/autogdb/docs/pwndbg/peda/xinfo.md
@@ -1,0 +1,28 @@
+
+
+
+
+# context
+
+## Description
+
+
+Print out the current register, instruction, and stack context.
+## Usage:
+
+
+```bash
+usage: context [-h] [subcontext ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`subcontext`|Submenu to display: 'reg', 'disasm', 'code', 'stack', 'backtrace', 'ghidra', and/or 'args'|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/peda/xprint.md
+++ b/autogdb/docs/pwndbg/peda/xprint.md
@@ -1,0 +1,32 @@
+
+
+
+
+# telescope
+
+## Description
+
+
+Recursively dereferences pointers starting at the specified address.
+## Usage:
+
+
+```bash
+usage: telescope [-h] [-r] [-f] [-i] [address] [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to telescope at. (default: %(default)s)|
+|`count`|The number of lines to show. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-r`|`--reverse`||Show <count> previous addresses instead of next ones (default: %(default)s)|
+|`-f`|`--frame`||Show the stack frame, from rsp to rbp (default: %(default)s)|
+|`-i`|`--inverse`||Show the stack reverse growth (default: %(default)s)|

--- a/autogdb/docs/pwndbg/peda/xuntil.md
+++ b/autogdb/docs/pwndbg/peda/xuntil.md
@@ -1,0 +1,28 @@
+
+
+
+
+# xuntil
+
+## Description
+
+
+Continue execution until an address or function.
+## Usage:
+
+
+```bash
+usage: xuntil [-h] target
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`target`|Address or function to stop execution at|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/pie/breakrva.md
+++ b/autogdb/docs/pwndbg/pie/breakrva.md
@@ -1,0 +1,29 @@
+
+
+
+
+# breakrva
+
+## Description
+
+
+Break at RVA from PIE base.
+## Usage:
+
+
+```bash
+usage: breakrva [-h] [offset] [module]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`offset`|Offset to add. (default: %(default)s)|
+|`module`|Module to choose as base. Defaults to the target executable. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/pie/piebase.md
+++ b/autogdb/docs/pwndbg/pie/piebase.md
@@ -1,0 +1,29 @@
+
+
+
+
+# piebase
+
+## Description
+
+
+Calculate VA of RVA from PIE base.
+## Usage:
+
+
+```bash
+usage: piebase [-h] [offset] [module]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`offset`|Offset from PIE base. (default: %(default)s)|
+|`module`|Module to choose as base. Defaults to the target executable. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/plist/plist.md
+++ b/autogdb/docs/pwndbg/plist/plist.md
@@ -1,0 +1,156 @@
+
+
+
+
+# plist
+
+## Description
+
+
+Dumps the elements of a linked list.
+
+This command traverses the linked list beginning at a given element, dumping its
+contents and the contents of all the elements that come after it in the list.
+Traversal is configurable and can handle multiple types of linked lists, but will
+always stop when a cycle is detected.
+
+The path to the first element can be any GDB expression that evaluates to either
+the first element directly, or a to pointer to it. The next element is the name
+of the field containing the next pointer, in either the structure itself or in
+the structure given by --inner.
+
+An address value may be given with --sentinel that signals the end of the list.
+By default, the value used is NULL (0).
+
+If only one field inside each node is desired, it can be printed exclusively by
+specifying its name with --field.
+
+This command supports traversing three types of linked lists, classified by how
+the next pointer can be found in the structure and what type it is:
+    1 - Next pointer is field of structure, type is the same as structure.
+    2 - Next pointer is field of inner nested structure, pointed to type is the
+        same as outer structure.
+    3 - Next pointer is field of inner nested structure, pointed to type is the
+        same as inner structure.
+Types 2 and 3 require --inner to be specified.
+
+Example 1:
+
+```
+struct node {
+    int value;
+    struct node *next;
+};
+struct node node_c = { 2, NULL };
+struct node node_b = { 1, &node_c };
+struct node node_a = { 0, &node_b };
+```
+
+pwndbg> plist node_a next
+0x4000011050 <node_a>: {
+  value = 0,
+  next = 0x4000011040 <node_b>
+}
+0x4000011040 <node_b>: {
+  value = 1,
+  next = 0x4000011010 <node_c>
+}
+0x4000011010 <node_c>: {
+  value = 2,
+  next = 0x0
+}
+
+Example 2:
+
+```
+struct node_inner_a {
+    struct node_inner_a *next;
+};
+struct inner_a_node {
+    int value;
+    struct node_inner_a inner;
+};
+struct inner_a_node inner_a_node_c = { 2, { NULL } };
+struct inner_a_node inner_a_node_b = { 1, { &inner_a_node_c.inner } };
+struct inner_a_node inner_a_node_a = { 0, { &inner_a_node_b.inner } };
+```
+
+pwndbg> plist inner_a_node_a -i inner next
+0x4000011070 <inner_a_node_a>: {
+  value = 0,
+  inner = {
+    next = 0x4000011068 <inner_a_node_b+8>
+  }
+}
+0x4000011060 <inner_a_node_b>: {
+  value = 1,
+  inner = {
+    next = 0x4000011028 <inner_a_node_c+8>
+  }
+}
+0x4000011020 <inner_a_node_c>: {
+  value = 2,
+  inner = {
+    next = 0x0
+  }
+}
+
+Example 3:
+
+```
+struct inner_b_node;
+struct node_inner_b {
+    struct inner_b_node *next;
+};
+struct inner_b_node {
+    int value;
+    struct node_inner_b inner;
+};
+struct inner_b_node inner_b_node_c = { 2, { NULL } };
+struct inner_b_node inner_b_node_b = { 1, { &inner_b_node_c } };
+struct inner_b_node inner_b_node_a = { 0, { &inner_b_node_b } };
+```
+
+pwndbg> plist inner_b_node_a -i inner next
+0x4000011090 <inner_b_node_a>: {
+  value = 0,
+  inner = {
+    next = 0x4000011080 <inner_b_node_b>
+  }
+}
+0x4000011080 <inner_b_node_b>: {
+  value = 1,
+  inner = {
+    next = 0x4000011030 <inner_b_node_c>
+  }
+}
+0x4000011030 <inner_b_node_c>: {
+  value = 2,
+  inner = {
+    next = 0x0
+  }
+}
+
+
+## Usage:
+
+
+```bash
+usage: plist [-h] [-s SENTINEL] [-i INNER_NAME] [-f FIELD_NAME] path next
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`path`|The first element of the linked list|
+|`next`|The name of the field pointing to the next element in the list|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-s`|`--sentinel`|`0`|The address that stands in for an end of list marker in a non-cyclic list (default: %(default)s)|
+|`-i`|`--inner`|`None`|The name of the inner nested structure where the next pointer is stored|
+|`-f`|`--field`|`None`|The name of the field to be displayed, if only one is desired|

--- a/autogdb/docs/pwndbg/probeleak/probeleak.md
+++ b/autogdb/docs/pwndbg/probeleak/probeleak.md
@@ -1,0 +1,39 @@
+
+
+
+
+# probeleak
+
+## Description
+
+
+
+Pointer scan for possible offset leaks.
+Examples:
+    probeleak $rsp 0x64 - leaks 0x64 bytes starting at stack pointer and search for valid pointers
+    probeleak $rsp 0x64 --max-dist 0x10 - as above, but pointers may point 0x10 bytes outside of memory page
+    probeleak $rsp 0x64 --point-to libc --max-ptrs 1 --flags rwx - leaks 0x64 bytes starting at stack pointer and search for one valid pointer which points to a libc rwx page
+
+## Usage:
+
+
+```bash
+usage: probeleak [-h] [--max-distance MAX_DISTANCE] [--point-to POINT_TO] [--max-ptrs MAX_PTRS] [--flags FLAGS] [address] [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|Leak memory address (default: %(default)s)|
+|`count`|Leak size in bytes (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+||`--max-distance`|`0`|Max acceptable distance between memory page boundary and leaked pointer (default: %(default)s)|
+||`--point-to`|`None`|Mapping name of the page that you want the pointers point to|
+||`--max-ptrs`|`0`|Stop search after find n pointers, default 0 (default: %(default)s)|
+||`--flags`|`None`|flags of the page that you want the pointers point to. [e.g. rwx]|

--- a/autogdb/docs/pwndbg/procinfo/pid.md
+++ b/autogdb/docs/pwndbg/procinfo/pid.md
@@ -1,0 +1,22 @@
+
+
+
+
+# pid
+
+## Description
+
+
+Gets the pid.
+## Usage:
+
+
+```bash
+usage: pid [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/procinfo/procinfo.md
+++ b/autogdb/docs/pwndbg/procinfo/procinfo.md
@@ -1,0 +1,22 @@
+
+
+
+
+# procinfo
+
+## Description
+
+
+Display information about the running process.
+## Usage:
+
+
+```bash
+usage: procinfo [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/radare2/r2.md
+++ b/autogdb/docs/pwndbg/radare2/r2.md
@@ -1,0 +1,30 @@
+
+
+
+
+# r2
+
+## Description
+
+
+Launches radare2.
+## Usage:
+
+
+```bash
+usage: r2 [-h] [--no-seek] [--no-rebase] [arguments ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`arguments`|Arguments to pass to radare|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+||`--no-seek`||Do not seek to current pc (default: %(default)s)|
+||`--no-rebase`||Do not set the base address for PIE according to the current mapping (default: %(default)s)|

--- a/autogdb/docs/pwndbg/radare2/r2pipe.md
+++ b/autogdb/docs/pwndbg/radare2/r2pipe.md
@@ -1,0 +1,28 @@
+
+
+
+
+# r2pipe
+
+## Description
+
+
+Execute stateful radare2 commands through r2pipe.
+## Usage:
+
+
+```bash
+usage: r2pipe [-h] arguments [arguments ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`arguments`|Arguments to pass to r2pipe|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/reload/reinit_pwndbg.md
+++ b/autogdb/docs/pwndbg/reload/reinit_pwndbg.md
@@ -1,0 +1,22 @@
+
+
+
+
+# reinit_pwndbg
+
+## Description
+
+
+Makes pwndbg reinitialize all state.
+## Usage:
+
+
+```bash
+usage: reinit_pwndbg [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/reload/reload.md
+++ b/autogdb/docs/pwndbg/reload/reload.md
@@ -1,0 +1,22 @@
+
+
+
+
+# reload
+
+## Description
+
+
+Reload pwndbg.
+## Usage:
+
+
+```bash
+usage: reload [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/rizin/rz.md
+++ b/autogdb/docs/pwndbg/rizin/rz.md
@@ -1,0 +1,30 @@
+
+
+
+
+# rz
+
+## Description
+
+
+Launches rizin.
+## Usage:
+
+
+```bash
+usage: rz [-h] [--no-seek] [--no-rebase] [arguments ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`arguments`|Arguments to pass to rizin|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+||`--no-seek`||Do not seek to current pc (default: %(default)s)|
+||`--no-rebase`||Do not set the base address for PIE according to the current mapping (default: %(default)s)|

--- a/autogdb/docs/pwndbg/rizin/rzpipe.md
+++ b/autogdb/docs/pwndbg/rizin/rzpipe.md
@@ -1,0 +1,28 @@
+
+
+
+
+# rzpipe
+
+## Description
+
+
+Execute stateful rizin commands through rzpipe.
+## Usage:
+
+
+```bash
+usage: rzpipe [-h] arguments [arguments ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`arguments`|Arguments to pass to rzpipe|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/rop/rop.md
+++ b/autogdb/docs/pwndbg/rop/rop.md
@@ -1,0 +1,29 @@
+
+
+
+
+# rop
+
+## Description
+
+
+Dump ROP gadgets with Jon Salwan's ROPgadget tool.
+## Usage:
+
+
+```bash
+usage: rop [-h] [--grep GREP] [argument ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`argument`|Arguments to pass to ROPgadget|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+||`--grep`|`None`|String to grep the output for|

--- a/autogdb/docs/pwndbg/ropper/ropper.md
+++ b/autogdb/docs/pwndbg/ropper/ropper.md
@@ -1,0 +1,28 @@
+
+
+
+
+# ropper
+
+## Description
+
+
+ROP gadget search with ropper.
+## Usage:
+
+
+```bash
+usage: ropper [-h] [argument ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`argument`|Arguments to pass to ropper|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/search/search.md
+++ b/autogdb/docs/pwndbg/search/search.md
@@ -1,0 +1,51 @@
+
+
+
+
+# search
+
+## Description
+
+
+Search memory for byte sequences, strings, pointers, and integer values.
+
+By default search results are cached. If you want to cache all results, but only print a subset, use --trunc-out. If you want to cache only a subset of results, and print the results immediately, use --limit. The latter is specially useful if you're searching a huge section of memory.
+
+
+## Usage:
+
+
+```bash
+usage: search [-h] [-t {byte,short,word,dword,qword,pointer,string,bytes}] [-1] [-2] [-4] [-8] [-p] [-x] [-e] [-w] [-s STEP] [-l LIMIT] [-a ALIGNED] [--save] [--no-save] [-n]
+              [--trunc-out]
+              value [mapping_name]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`value`|Value to search for|
+|`mapping_name`|Mapping to search [e.g. libc]|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-t`|`--type`|`bytes`|Size of search target (default: %(default)s)|
+|`-1`|`--byte`|`None`|Search for a 1-byte integer|
+|`-2`|`--short`|`None`|Search for a 2-byte integer|
+|`-4`|`--dword`|`None`|Search for a 4-byte integer|
+|`-8`|`--qword`|`None`|Search for an 8-byte integer|
+|`-p`|`--pointer`|`None`|Search for a pointer-width integer|
+|`-x`|`--hex`||Target is a hex-encoded (for bytes/strings) (default: %(default)s)|
+|`-e`|`--executable`||Search executable segments only (default: %(default)s)|
+|`-w`|`--writable`||Search writable segments only (default: %(default)s)|
+|`-s`|`--step`|`None`|Step search address forward to next alignment after each hit (ex: 0x1000)|
+|`-l`|`--limit`|`None`|Max results before quitting the search. Differs from --trunc-out in that it will not save all search results before quitting|
+|`-a`|`--aligned`|`None`|Result must be aligned to this byte boundary|
+||`--save`|`None`|Save results for further searches with --next. Default comes from config 'auto-save-search'|
+||`--no-save`|`None`|Invert --save|
+|`-n`|`--next`||Search only locations returned by previous search with --save (default: %(default)s)|
+||`--trunc-out`||Truncate the output to 20 results. Differs from --limit in that it will first save all search results (default: %(default)s)|

--- a/autogdb/docs/pwndbg/segments/fsbase.md
+++ b/autogdb/docs/pwndbg/segments/fsbase.md
@@ -1,0 +1,22 @@
+
+
+
+
+# fsbase
+
+## Description
+
+
+Prints out the FS base address. See also $fsbase.
+## Usage:
+
+
+```bash
+usage: fsbase [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/segments/gsbase.md
+++ b/autogdb/docs/pwndbg/segments/gsbase.md
@@ -1,0 +1,22 @@
+
+
+
+
+# gsbase
+
+## Description
+
+
+Prints out the GS base address. See also $gsbase.
+## Usage:
+
+
+```bash
+usage: gsbase [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/sigreturn/sigreturn.md
+++ b/autogdb/docs/pwndbg/sigreturn/sigreturn.md
@@ -1,0 +1,30 @@
+
+
+
+
+# sigreturn
+
+## Description
+
+
+Display the SigreturnFrame at the specific address
+## Usage:
+
+
+```bash
+usage: sigreturn [-h] [-a] [-p] [address]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to read the frame from|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-a`|`--all`||Show all values in the frame in addition to common registers (default: %(default)s)|
+|`-p`|`--print`||Show addresses of frame values (default: %(default)s)|

--- a/autogdb/docs/pwndbg/slab/slab.md
+++ b/autogdb/docs/pwndbg/slab/slab.md
@@ -1,0 +1,28 @@
+
+
+
+
+# slab
+
+## Description
+
+
+Prints information about the slab allocator
+## Usage:
+
+
+```bash
+usage: slab [-h] {list,info,contains} ...
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`command`|`None`|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/spray/spray.md
+++ b/autogdb/docs/pwndbg/spray/spray.md
@@ -1,0 +1,31 @@
+
+
+
+
+# spray
+
+## Description
+
+
+Spray memory with cyclic() generated values
+## Usage:
+
+
+```bash
+usage: spray [-h] [--value VALUE] [-x] addr [length]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address to spray|
+|`length`|Length of byte sequence, when unspecified sprays until the end of vmmap which address belongs to (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+||`--value`|`None`|Value to spray memory with, when prefixed with '0x' treated as hex string encoded big-endian|
+|`-x`|`--only-funcptrs`||Spray only addresses whose values points to executable pages (default: %(default)s)|

--- a/autogdb/docs/pwndbg/stack/retaddr.md
+++ b/autogdb/docs/pwndbg/stack/retaddr.md
@@ -1,0 +1,22 @@
+
+
+
+
+# retaddr
+
+## Description
+
+
+Print out the stack addresses that contain return addresses.
+## Usage:
+
+
+```bash
+usage: retaddr [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/start/entry.md
+++ b/autogdb/docs/pwndbg/start/entry.md
@@ -1,0 +1,45 @@
+
+
+
+
+# entry
+
+## Description
+
+
+
+Start the debugged program stopping at its entrypoint address.
+
+Note that the entrypoint may not be the first instruction executed
+by the program. If you want to stop on the first executed instruction,
+use the GDB's `starti` command.
+
+Args may include "*", or "[...]"; they are expanded using the
+shell that will start the program (specified by the "$SHELL" environment
+variable).  Input and output redirection with ">", "<", or ">>"
+are also allowed.
+
+With no arguments, uses arguments last specified (with "run" or
+"set args").  To cancel previous arguments and run with no arguments,
+use "set args" without arguments.
+
+To start the inferior without using a shell, use "set startup-with-shell off".
+
+## Usage:
+
+
+```bash
+usage: entry [-h] [args ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`args`|The arguments to run the binary with. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/start/sstart.md
+++ b/autogdb/docs/pwndbg/start/sstart.md
@@ -1,0 +1,22 @@
+
+
+
+
+# sstart
+
+## Description
+
+
+Alias for 'tbreak __libc_start_main; run'.
+## Usage:
+
+
+```bash
+usage: sstart [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/start/start.md
+++ b/autogdb/docs/pwndbg/start/start.md
@@ -1,0 +1,43 @@
+
+
+
+
+# start
+
+## Description
+
+
+
+Start the debugged program stopping at the first convenient location
+from this list: main, _main, start, _start, init or _init.
+You may specify arguments to give it.
+
+Args may include "*", or "[...]"; they are expanded using the
+shell that will start the program (specified by the "$SHELL" environment
+variable).  Input and output redirection with ">", "<", or ">>"
+are also allowed.
+
+With no arguments, uses arguments last specified (with "run" or
+"set args").  To cancel previous arguments and run with no arguments,
+use "set args" without arguments.
+
+To start the inferior without using a shell, use "set startup-with-shell off".
+
+## Usage:
+
+
+```bash
+usage: start [-h] [args ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`args`|The arguments to run the binary with.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/telescope/stack.md
+++ b/autogdb/docs/pwndbg/telescope/stack.md
@@ -1,0 +1,31 @@
+
+
+
+
+# stack
+
+## Description
+
+
+Dereferences on stack data with specified count and offset.
+## Usage:
+
+
+```bash
+usage: stack [-h] [-f] [-i] [count] [offset]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`count`|number of element to dump (default: %(default)s)|
+|`offset`|Element offset from $sp (support negative offset) (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-f`|`--frame`||Show the stack frame, from rsp to rbp (default: %(default)s)|
+|`-i`|`--inverse`||Show reverse stack growth (default: %(default)s)|

--- a/autogdb/docs/pwndbg/telescope/stackf.md
+++ b/autogdb/docs/pwndbg/telescope/stackf.md
@@ -1,0 +1,29 @@
+
+
+
+
+# stackf
+
+## Description
+
+
+Dereferences on stack data, printing the entire stack frame with specified count and offset .
+## Usage:
+
+
+```bash
+usage: stackf [-h] [count] [offset]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`count`|number of element to dump (default: %(default)s)|
+|`offset`|Element offset from $sp (support negative offset) (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/telescope/telescope.md
+++ b/autogdb/docs/pwndbg/telescope/telescope.md
@@ -1,0 +1,32 @@
+
+
+
+
+# telescope
+
+## Description
+
+
+Recursively dereferences pointers starting at the specified address.
+## Usage:
+
+
+```bash
+usage: telescope [-h] [-r] [-f] [-i] [address] [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to telescope at. (default: %(default)s)|
+|`count`|The number of lines to show. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-r`|`--reverse`||Show <count> previous addresses instead of next ones (default: %(default)s)|
+|`-f`|`--frame`||Show the stack frame, from rsp to rbp (default: %(default)s)|
+|`-i`|`--inverse`||Show the stack reverse growth (default: %(default)s)|

--- a/autogdb/docs/pwndbg/tips/tips.md
+++ b/autogdb/docs/pwndbg/tips/tips.md
@@ -1,0 +1,23 @@
+
+
+
+
+# tips
+
+## Description
+
+
+Shows tips.
+## Usage:
+
+
+```bash
+usage: tips [-h] [-a]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-a`|`--all`||Show all tips. (default: %(default)s)|

--- a/autogdb/docs/pwndbg/tls/threads.md
+++ b/autogdb/docs/pwndbg/tls/threads.md
@@ -1,0 +1,29 @@
+
+
+
+
+# threads
+
+## Description
+
+
+List all threads belonging to the selected inferior.
+## Usage:
+
+
+```bash
+usage: threads [-h] [-c] [num_threads]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`num_threads`|Number of threads to display. Omit to display all threads.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-c`|`--config`||Respect context-max-threads config to limit number of threads displayed. (default: %(default)s)|

--- a/autogdb/docs/pwndbg/tls/tls.md
+++ b/autogdb/docs/pwndbg/tls/tls.md
@@ -1,0 +1,23 @@
+
+
+
+
+# tls
+
+## Description
+
+
+Print out base address of the current Thread Local Storage (TLS).
+## Usage:
+
+
+```bash
+usage: tls [-h] [-p]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-p`|`--pthread-self`||Try to get the address of TLS by calling pthread_self(). (default: %(default)s)|

--- a/autogdb/docs/pwndbg/valist/valist.md
+++ b/autogdb/docs/pwndbg/valist/valist.md
@@ -1,0 +1,29 @@
+
+
+
+
+# valist
+
+## Description
+
+
+Dumps the arguments of a va_list.
+## Usage:
+
+
+```bash
+usage: valist [-h] addr [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|Address of the va_list|
+|`count`|Number of arguments to dump (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/version/bugreport.md
+++ b/autogdb/docs/pwndbg/version/bugreport.md
@@ -1,0 +1,24 @@
+
+
+
+
+# bugreport
+
+## Description
+
+
+Generate a bug report.
+## Usage:
+
+
+```bash
+usage: bugreport [-h] [--run-browser | --use-gh]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-b`|`--run-browser`||Open browser on github/issues/new (default: %(default)s)|
+|`-g`|`--use-gh`||Create issue using Github CLI (default: %(default)s)|

--- a/autogdb/docs/pwndbg/version/version.md
+++ b/autogdb/docs/pwndbg/version/version.md
@@ -1,0 +1,22 @@
+
+
+
+
+# version
+
+## Description
+
+
+Displays GDB, Python, and pwndbg versions.
+## Usage:
+
+
+```bash
+usage: version [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/vmmap/vmmap.md
+++ b/autogdb/docs/pwndbg/vmmap/vmmap.md
@@ -1,0 +1,47 @@
+
+
+
+
+# vmmap
+
+## Description
+
+
+Print virtual memory map pages.
+
+Unnamed mappings are named as [anon_%#x] where %#x is high part of their start address. This is useful for filtering with `vmmap` or `search` commands.
+
+Known issues with vmmap:
+For QEMU user targets, the QEMU's gdbstub does not provide memory maps information to GDB until [0] is finished & merged. We try to deal with it without parsing the QEMU process' /proc/$pid/maps file, but if our approach fails, we simply create a [0, 0xffff...] vmmap which is not great and may result in lack of proper colors or inability to search memory with the `search` command.
+
+For QEMU kernel, we use gdb-pt-dump that parses page tables from the guest by reading /proc/$pid/mem of QEMU process. If this does not work for you, use `set kernel-vmmap-via-page-tables off` to refer to our old method of reading vmmap info from `monitor info mem` command exposed by QEMU. Note that the latter may be slower and will not give full vmmaps permission information.
+
+For coredump debugging, GDB also lacks all vmmap info but we do our best to get it back by using the `info proc mappings` and `maintenance info sections` commands.
+
+As a last resort, we sometimes try to explore the addresses in CPU registers and if they are readable by GDB, we determine their bounds and create an "<explored>" vmmap. However, this method is slow and is not used on each GDB stop.
+
+Memory pages can also be added manually with the use of vmmap_add, vmmap_clear and vmmap_load commands. This may be useful for bare metal debugging.
+
+[0] https://lore.kernel.org/all/20220221030910.3203063-1-dominik.b.czarnota@gmail.com/
+## Usage:
+
+
+```bash
+usage: vmmap [-h] [-w] [-x] [-A LINES_AFTER] [-B LINES_BEFORE] [gdbval_or_str]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`gdbval_or_str`|Address or module name filter|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|
+|`-w`|`--writable`||Display writable maps only (default: %(default)s)|
+|`-x`|`--executable`||Display executable maps only (default: %(default)s)|
+|`-A`|`--lines-after`|`1`|Number of pages to display after result (default: %(default)s)|
+|`-B`|`--lines-before`|`1`|Number of pages to display before result (default: %(default)s)|

--- a/autogdb/docs/pwndbg/vmmap/vmmap_add.md
+++ b/autogdb/docs/pwndbg/vmmap/vmmap_add.md
@@ -1,0 +1,31 @@
+
+
+
+
+# vmmap_add
+
+## Description
+
+
+Add virtual memory map page.
+## Usage:
+
+
+```bash
+usage: vmmap_add [-h] start size [flags] [offset]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`start`|Starting virtual address|
+|`size`|Size of the address space, in bytes|
+|`flags`|Flags set by the ELF file, see PF_X, PF_R, PF_W (default: %(default)s)|
+|`offset`|Offset into the original ELF file that the data is loaded from (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/vmmap/vmmap_clear.md
+++ b/autogdb/docs/pwndbg/vmmap/vmmap_clear.md
@@ -1,0 +1,22 @@
+
+
+
+
+# vmmap_clear
+
+## Description
+
+
+Clear the vmmap cache.
+## Usage:
+
+
+```bash
+usage: vmmap_clear [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/vmmap/vmmap_load.md
+++ b/autogdb/docs/pwndbg/vmmap/vmmap_load.md
@@ -1,0 +1,28 @@
+
+
+
+
+# vmmap_load
+
+## Description
+
+
+Load virtual memory map pages from ELF file.
+## Usage:
+
+
+```bash
+usage: vmmap_load [-h] [filename]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`filename`|ELF filename, by default uses current loaded filename.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/bc.md
+++ b/autogdb/docs/pwndbg/windbg/bc.md
@@ -1,0 +1,28 @@
+
+
+
+
+# bc
+
+## Description
+
+
+Clear the breakpoint with the specified index.
+## Usage:
+
+
+```bash
+usage: bc [-h] [which]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`which`|Index of the breakpoint to clear. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/bd.md
+++ b/autogdb/docs/pwndbg/windbg/bd.md
@@ -1,0 +1,28 @@
+
+
+
+
+# bd
+
+## Description
+
+
+Disable the breakpoint with the specified index.
+## Usage:
+
+
+```bash
+usage: bd [-h] [which]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`which`|Index of the breakpoint to disable. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/be.md
+++ b/autogdb/docs/pwndbg/windbg/be.md
@@ -1,0 +1,28 @@
+
+
+
+
+# be
+
+## Description
+
+
+Enable the breakpoint with the specified index.
+## Usage:
+
+
+```bash
+usage: be [-h] [which]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`which`|Index of the breakpoint to enable. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/bl.md
+++ b/autogdb/docs/pwndbg/windbg/bl.md
@@ -1,0 +1,22 @@
+
+
+
+
+# bl
+
+## Description
+
+
+List breakpoints.
+## Usage:
+
+
+```bash
+usage: bl [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/bp.md
+++ b/autogdb/docs/pwndbg/windbg/bp.md
@@ -1,0 +1,28 @@
+
+
+
+
+# bp
+
+## Description
+
+
+Set a breakpoint at the specified address.
+## Usage:
+
+
+```bash
+usage: bp [-h] where
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`where`|The address to break at.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/da.md
+++ b/autogdb/docs/pwndbg/windbg/da.md
@@ -1,0 +1,29 @@
+
+
+
+
+# da
+
+## Description
+
+
+Dump a string at the specified address.
+## Usage:
+
+
+```bash
+usage: da [-h] address [max]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|Address to dump|
+|`max`|Maximum string length (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/db.md
+++ b/autogdb/docs/pwndbg/windbg/db.md
@@ -1,0 +1,29 @@
+
+
+
+
+# db
+
+## Description
+
+
+Starting at the specified address, dump N bytes.
+## Usage:
+
+
+```bash
+usage: db [-h] address [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to dump from.|
+|`count`|The number of bytes to dump. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/dc.md
+++ b/autogdb/docs/pwndbg/windbg/dc.md
@@ -1,0 +1,29 @@
+
+
+
+
+# dc
+
+## Description
+
+
+Starting at the specified address, hexdump.
+## Usage:
+
+
+```bash
+usage: dc [-h] address [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to dump from.|
+|`count`|The number of bytes to hexdump. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/dd.md
+++ b/autogdb/docs/pwndbg/windbg/dd.md
@@ -1,0 +1,29 @@
+
+
+
+
+# dd
+
+## Description
+
+
+Starting at the specified address, dump N dwords.
+## Usage:
+
+
+```bash
+usage: dd [-h] address [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to dump from.|
+|`count`|The number of dwords to dump. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/dds.md
+++ b/autogdb/docs/pwndbg/windbg/dds.md
@@ -1,0 +1,28 @@
+
+
+
+
+# dds
+
+## Description
+
+
+Dump pointers and symbols at the specified address.
+## Usage:
+
+
+```bash
+usage: dds [-h] addr
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`addr`|The address to dump from.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/dq.md
+++ b/autogdb/docs/pwndbg/windbg/dq.md
@@ -1,0 +1,29 @@
+
+
+
+
+# dq
+
+## Description
+
+
+Starting at the specified address, dump N qwords.
+## Usage:
+
+
+```bash
+usage: dq [-h] address [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to dump from.|
+|`count`|The number of qwords to dump. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/ds.md
+++ b/autogdb/docs/pwndbg/windbg/ds.md
@@ -1,0 +1,29 @@
+
+
+
+
+# ds
+
+## Description
+
+
+Dump a string at the specified address.
+## Usage:
+
+
+```bash
+usage: ds [-h] address [max]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|Address to dump|
+|`max`|Maximum string length (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/dw.md
+++ b/autogdb/docs/pwndbg/windbg/dw.md
@@ -1,0 +1,29 @@
+
+
+
+
+# dw
+
+## Description
+
+
+Starting at the specified address, dump N words.
+## Usage:
+
+
+```bash
+usage: dw [-h] address [count]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to dump from.|
+|`count`|The number of words to dump. (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/eb.md
+++ b/autogdb/docs/pwndbg/windbg/eb.md
@@ -1,0 +1,29 @@
+
+
+
+
+# eb
+
+## Description
+
+
+Write hex bytes at the specified address.
+## Usage:
+
+
+```bash
+usage: eb [-h] address [data ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to write to.|
+|`data`|The bytes to write.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/ed.md
+++ b/autogdb/docs/pwndbg/windbg/ed.md
@@ -1,0 +1,29 @@
+
+
+
+
+# ed
+
+## Description
+
+
+Write hex dwords at the specified address.
+## Usage:
+
+
+```bash
+usage: ed [-h] address [data ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to write to.|
+|`data`|The dwords to write.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/eq.md
+++ b/autogdb/docs/pwndbg/windbg/eq.md
@@ -1,0 +1,29 @@
+
+
+
+
+# eq
+
+## Description
+
+
+Write hex qwords at the specified address.
+## Usage:
+
+
+```bash
+usage: eq [-h] address [data ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to write to.|
+|`data`|The qwords to write.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/ew.md
+++ b/autogdb/docs/pwndbg/windbg/ew.md
@@ -1,0 +1,29 @@
+
+
+
+
+# ew
+
+## Description
+
+
+Write hex words at the specified address.
+## Usage:
+
+
+```bash
+usage: ew [-h] address [data ...]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to write to.|
+|`data`|The words to write.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/ez.md
+++ b/autogdb/docs/pwndbg/windbg/ez.md
@@ -1,0 +1,29 @@
+
+
+
+
+# ez
+
+## Description
+
+
+Write a string at the specified address.
+## Usage:
+
+
+```bash
+usage: ez [-h] address data
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to write to.|
+|`data`|The string to write.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/eza.md
+++ b/autogdb/docs/pwndbg/windbg/eza.md
@@ -1,0 +1,29 @@
+
+
+
+
+# eza
+
+## Description
+
+
+Write a string at the specified address.
+## Usage:
+
+
+```bash
+usage: eza [-h] address data
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to write to.|
+|`data`|The string to write.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/go.md
+++ b/autogdb/docs/pwndbg/windbg/go.md
@@ -1,0 +1,22 @@
+
+
+
+
+# go
+
+## Description
+
+
+Windbg compatibility alias for 'continue' command.
+## Usage:
+
+
+```bash
+usage: go [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/k.md
+++ b/autogdb/docs/pwndbg/windbg/k.md
@@ -1,0 +1,22 @@
+
+
+
+
+# k
+
+## Description
+
+
+Print a backtrace (alias 'bt').
+## Usage:
+
+
+```bash
+usage: k [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/ln.md
+++ b/autogdb/docs/pwndbg/windbg/ln.md
@@ -1,0 +1,28 @@
+
+
+
+
+# ln
+
+## Description
+
+
+List the symbols nearest to the provided value.
+## Usage:
+
+
+```bash
+usage: ln [-h] [value]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`value`|The address you want the name of.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/pc.md
+++ b/autogdb/docs/pwndbg/windbg/pc.md
@@ -1,0 +1,22 @@
+
+
+
+
+# pc
+
+## Description
+
+
+Windbg compatibility alias for 'nextcall' command.
+## Usage:
+
+
+```bash
+usage: pc [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/windbg/peb.md
+++ b/autogdb/docs/pwndbg/windbg/peb.md
@@ -1,0 +1,22 @@
+
+
+
+
+# peb
+
+## Description
+
+
+Not be windows.
+## Usage:
+
+
+```bash
+usage: peb [-h]
+
+```
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/xinfo/xinfo.md
+++ b/autogdb/docs/pwndbg/xinfo/xinfo.md
@@ -1,0 +1,28 @@
+
+
+
+
+# xinfo
+
+## Description
+
+
+Shows offsets of the specified address from various useful locations.
+## Usage:
+
+
+```bash
+usage: xinfo [-h] [address]
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|Address to inspect (default: %(default)s)|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/xor/memfrob.md
+++ b/autogdb/docs/pwndbg/xor/memfrob.md
@@ -1,0 +1,29 @@
+
+
+
+
+# memfrob
+
+## Description
+
+
+Memfrobs a region of memory (xor with '*').
+## Usage:
+
+
+```bash
+usage: memfrob [-h] address count
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to start xoring at.|
+|`count`|The number of bytes to xor.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/docs/pwndbg/xor/xor.md
+++ b/autogdb/docs/pwndbg/xor/xor.md
@@ -1,0 +1,30 @@
+
+
+
+
+# xor
+
+## Description
+
+
+XOR `count` bytes at `address` with the key `key`.
+## Usage:
+
+
+```bash
+usage: xor [-h] address key count
+
+```
+## Positional Arguments
+
+|Positional Argument|Help|
+| :--- | :--- |
+|`address`|The address to start xoring at.|
+|`key`|The key to use.|
+|`count`|The number of bytes to xor.|
+
+## Optional Arguments
+
+|Short|Long|Default|Help|
+| :--- | :--- | :--- | :--- |
+|`-h`|`--help`||show this help message and exit|

--- a/autogdb/pwndbg.py
+++ b/autogdb/pwndbg.py
@@ -1,0 +1,23 @@
+from langchain.tools import tool
+from pathlib import Path
+
+CUR_DIR = Path(__file__).parent
+DOCS_DIR = CUR_DIR/'docs'/'pwndbg'
+
+def base_prompt() -> str:
+    return open(DOCS_DIR/'index.md').read()
+
+@tool("Read Command Docs")
+def read_command_docs(md_path:str):
+    """
+    Read the docs of the command.
+    :param md_path: The path to the markdown file to read. E.G. asm/asm.md
+    """
+    p = DOCS_DIR/md_path
+    if not p.exists():
+        return "No such file"
+    return p.read_text()
+
+if __name__ == '__main__':
+    print(base_prompt())
+    print(read_command_docs._run('asm/asm.md'))

--- a/server/run.sh
+++ b/server/run.sh
@@ -1,1 +1,8 @@
-uvicorn main:app --host 0.0.0.0 --port 5000 --reload
+PORT=8000
+
+if [ ! -z "$1" ] # first argument(optional) determines the port number
+then
+    PORT=$1
+fi
+
+uvicorn main:app --host 0.0.0.0 --port $PORT --reload


### PR DESCRIPTION
This incorporates the documentation from https://github.com/pwndbg/pwndbg/tree/dev/docs into the agent prompting system.

- Adds a list of all pwndbg commands into the base prompt
- Adds an agent tool `read_command_docs` that returns more detailed documentation about a specific command
- Makes the port number an optional argument in `server/run.sh`, as port 8000 is sometimes occupied by the system